### PR TITLE
Do not package stm32-rs submodule contents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["stm32", "embedded", "no_std"]
 categories = ["embedded", "no-std"]
 license = "MIT/Apache-2.0"
 edition = "2018"
+exclude = ["/stm32-rs"]
 
 # Change version in stm32ral.py, not in Cargo.toml!
 version = "0.3.0"

--- a/stm32ral.py
+++ b/stm32ral.py
@@ -65,6 +65,7 @@ keywords = ["stm32", "embedded", "no_std"]
 categories = ["embedded", "no-std"]
 license = "MIT/Apache-2.0"
 edition = "2018"
+exclude = ["/stm32-rs"]
 
 # Change version in stm32ral.py, not in Cargo.toml!
 version = "0.3.0"


### PR DESCRIPTION
This change reduces the size of the package down to ~2.8MB