### PR TITLE
Propagate the register size to masks, offsets, and enumerated values

### DIFF
--- a/src/stm32l0/peripherals/tim2.rs
+++ b/src/stm32l0/peripherals/tim2.rs
@@ -1850,9 +1850,9 @@ pub mod CNT {
     /// Low counter value
     pub mod CNT {
         /// Offset (0 bits)
-        pub const offset: u32 = 0;
+        pub const offset: u16 = 0;
         /// Mask (16 bits: 0xffff << 0)
-        pub const mask: u32 = 0xffff << offset;
+        pub const mask: u16 = 0xffff << offset;
         /// Read-only values (empty)
         pub mod R {}
         /// Write-only values (empty)
@@ -1868,9 +1868,9 @@ pub mod ARR {
     /// Low Auto-reload value
     pub mod ARR {
         /// Offset (0 bits)
-        pub const offset: u32 = 0;
+        pub const offset: u16 = 0;
         /// Mask (16 bits: 0xffff << 0)
-        pub const mask: u32 = 0xffff << offset;
+        pub const mask: u16 = 0xffff << offset;
         /// Read-only values (empty)
         pub mod R {}
         /// Write-only values (empty)
@@ -1886,9 +1886,9 @@ pub mod CCR1 {
     /// Low Capture/Compare 1 value
     pub mod CCR {
         /// Offset (0 bits)
-        pub const offset: u32 = 0;
+        pub const offset: u16 = 0;
         /// Mask (16 bits: 0xffff << 0)
-        pub const mask: u32 = 0xffff << offset;
+        pub const mask: u16 = 0xffff << offset;
         /// Read-only values (empty)
         pub mod R {}
         /// Write-only values (empty)

--- a/stm32ral.py
+++ b/stm32ral.py
@@ -143,10 +143,11 @@ class EnumeratedValue(Node):
     Has a name, description, and value.
     Belongs to one or more parent Fields.
     """
-    def __init__(self, name, desc, value):
+    def __init__(self, name, desc, value, register_size):
         self.name = name
         self.desc = desc
         self.value = value
+        self.register_size = register_size
         if self.name[0] in "0123456789":
             self.name = "_" + self.name
             print("Name started with a number:", self.name)
@@ -157,14 +158,14 @@ class EnumeratedValue(Node):
     def to_rust(self, field_width):
         return f"""
         /// 0b{self.value:0{field_width}b}: {escape_desc(self.desc)}
-        pub const {self.name}: u32 = 0b{self.value:0{field_width}b};"""
+        pub const {self.name}: u{self.register_size} = 0b{self.value:0{field_width}b};"""
 
     @classmethod
-    def from_svd(cls, svd, node):
+    def from_svd(cls, svd, node, register_size):
         name = get_string(node, 'name')
         desc = get_string(node, 'description')
         value = get_int(node, 'value')
-        return cls(name, desc, value)
+        return cls(name, desc, value, register_size)
 
     def __eq__(self, other):
         return (
@@ -207,7 +208,7 @@ class EnumeratedValues(Node):
         }}"""
 
     @classmethod
-    def from_svd(cls, svd, node):
+    def from_svd(cls, svd, node, register_size):
         usage = get_string(node, 'usage')
         if usage == "read":
             name = "R"
@@ -217,7 +218,7 @@ class EnumeratedValues(Node):
             name = "RW"
         evs = cls(name)
         for ev in node.findall('enumeratedValue'):
-            evs.values.append(EnumeratedValue.from_svd(svd, ev))
+            evs.values.append(EnumeratedValue.from_svd(svd, ev, register_size))
         return evs
 
     @classmethod
@@ -266,8 +267,9 @@ class Field(Node):
     EnumeratedValues: R, W, and RW.
     Belongs to a parent Register.
     May contain one or more child EnumeratedValues.
+    register_size is the size of the register containing this field
     """
-    def __init__(self, name, desc, width, offset, access, r, w, rw):
+    def __init__(self, name, desc, register_size, width, offset, access, r, w, rw):
         self.name = name
         self.desc = desc
         self.width = width
@@ -276,6 +278,7 @@ class Field(Node):
         self.r = r
         self.w = w
         self.rw = rw
+        self.register_size = register_size
         if self.name[0] in "0123456789":
             self.name = "_" + self.name
             print("Name started with a number:", self.name)
@@ -295,13 +298,14 @@ class Field(Node):
         else:
             mask = f"0x{mask:x}"
         bits = f"bit{'s' if self.width>1 else ''}"
+        ty = f"u{self.register_size}"
         return f"""
         /// {escape_desc(self.desc)}
         pub mod {self.name} {{
             /// Offset ({self.offset} bits)
-            pub const offset: u32 = {self.offset};
+            pub const offset: {ty} = {self.offset};
             /// Mask ({self.width} {bits}: {mask} << {self.offset})
-            pub const mask: u32 = {mask} << offset;
+            pub const mask: {ty} = {mask} << offset;
             {self.r.to_rust(self.width)}
             {self.w.to_rust(self.width)}
             {self.rw.to_rust(self.width)}
@@ -315,6 +319,13 @@ class Field(Node):
         width = get_int(node, 'bitWidth')
         offset = get_int(node, 'bitOffset')
         access = ctx.access
+        # Round up register_size to a size that's representable as a Rust
+        # unsigned integer. We probably will never see a register that's
+        # not a multiple of 8, so this might be overkill.
+        register_size = (ctx.size + 7) & (~7)
+        if register_size != register_size:
+            print(f"Field {name} will be represented using u{register_size}s, "
+                  f"although the register size is {ctx.size} bits")
         r = EnumeratedValues.empty("R")
         w = EnumeratedValues.empty("W")
         rw = EnumeratedValues.empty("RW")
@@ -324,7 +335,7 @@ class Field(Node):
                 evs = svd.find(f".//enumeratedValues[name='{df}']")
                 if evs is None:
                     raise ValueError(f"Can't find derivedFrom {df}")
-            evs = EnumeratedValues.from_svd(svd, evs)
+            evs = EnumeratedValues.from_svd(svd, evs, register_size)
             evsname = evs.name
             if evsname == "R":
                 r = evs
@@ -332,7 +343,7 @@ class Field(Node):
                 w = evs
             else:
                 rw = evs
-        field = cls(name, desc, width, offset, access, r, w, rw)
+        field = cls(name, desc, register_size, width, offset, access, r, w, rw)
         return field
 
     def __eq__(self, other):

--- a/stm32ral.py
+++ b/stm32ral.py
@@ -323,7 +323,7 @@ class Field(Node):
         # unsigned integer. We probably will never see a register that's
         # not a multiple of 8, so this might be overkill.
         register_size = (ctx.size + 7) & (~7)
-        if register_size != register_size:
+        if register_size != ctx.size:
             print(f"Field {name} will be represented using u{register_size}s, "
                   f"although the register size is {ctx.size} bits")
         r = EnumeratedValues.empty("R")


### PR DESCRIPTION
We're using the RAL generation script in the [imxrt-rs project](https://github.com/imxrt-rs/imxrt-rs). PWM registers on iMXRT processors are 16 bits. But, this RAL script always generates masks, offsets, and enumerated values that are hard-coded to `u32`s. When we try bit operations -- like those inlined by the `read_reg!`, `write_reg!`, or `modify_reg!` -- the compiler yells at us. We're trying to AND, OR, and shift `u32` values with `u16` registers.

The masks, offsets, and enumerated values for a field should be based on the associated register. This PR updates the RAL generation script to propagate the register size to the nodes that generate the corresponding Rust code. In our project, we see that the constants associated with PWM fields are now correctly represented as `u16`s. We also identify a few masks and offsets in this repo that should be `u16`, since the associated registers are 16-bits large.

Patch for the RAL script generated from imxrt-rs/imxrt-rs@0cff649.