### PR TITLE
Ensure alignment when computing reserved registers

### DIFF
--- a/stm32ral.py
+++ b/stm32ral.py
@@ -759,14 +759,6 @@ class PeripheralPrototype(Node):
                 raise RuntimeError("Unexpected register aliasing")
             if register.offset != address:
                 gaps = []
-                u32s = (register.offset - address) // 4
-                if u32s != 0:
-                    gaps.append(f"[u32; {u32s}]")
-                    address += u32s * 4
-                u16s = (register.offset - address) // 2
-                if u16s != 0:
-                    gaps.append(f"[u16; {u16s}]")
-                    address += u16s * 2
                 u8s = register.offset - address
                 if u8s != 0:
                     gaps.append(f"[u8; {u8s}]")


### PR DESCRIPTION
If the routine for computing reserved peripheral memory places at least one `u32` after a `u16` register, the compiler could insert an extra `u16` of padding to align the `u32` reservation. The extra padding is not considered by the routine. This can result in incorrect register offsets for all registers placed after the reservation.

This PR ensures that we only use larger-than-byte padding when the address is aligned for that primitive. If the address isn't aligned, use the next-largest primitive. Byte array reservations should be the safest approach, but going that route changes all `_reserved` members of all register blocks, making it harder to see what peripherals were affected by this issue.

When I run `make`, I'm generating unrelated changes throughout the source tree, so I'm only checking in the script changes and the changes & tests for the TIM2 peripherals. There might be other instances of this issue that this PR does not address.